### PR TITLE
fix nested quotes in server.py

### DIFF
--- a/shiradl/server.py
+++ b/shiradl/server.py
@@ -15,14 +15,14 @@ def send(server: WebsocketServer, data):
 def message_received(client, server, message):
     if len(message) > 200:
         message = message[:200]+"..."
-    print(f"Client({client["id"]}) said: {message}")
+    print(f"Client({client['id']}) said: {message}")
 	
 def nclient(client, server: WebsocketServer):
-	print("new client joined:", client["id"])
-	send(server, json.dumps(f"hello from server! you are client {client["id"]}"))
+	print("new client joined:", client['id'])
+	send(server, json.dumps(f"hello from server! you are client {client['id']}"))
 
 def lclient(client, server: WebsocketServer):
-	print(f"client {client["id"]} disconnected")
+	print(f"client {client['id']} disconnected")
 		
 
 def server():


### PR DESCRIPTION
Tried to use the program, and it didn't work:

```
$ python -m shiradl "..."
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/alex/shira/shira/shiradl/__main__.py", line 4, in <module>
    from .server import server
  File "/home/alex/shira/shira/shiradl/server.py", line 18
    print(f"Client({client["id"]}) said: {message}")
                            ^^
SyntaxError: f-string: unmatched '['
```
Found the following thread on stackoverflow - https://stackoverflow.com/questions/67540413/f-string-unmatched-in-line-with-function-call and wrote a fix