### PR TITLE
Add stronger date metadata parsing

### DIFF
--- a/shiradl/metadata.py
+++ b/shiradl/metadata.py
@@ -394,16 +394,29 @@ class MBSong:
 				break
 
 	def get_date_str(self):
+		return_val = None
 		if self.song_dict is None:
 			return None
-		frd = self.song_dict.get("first-release-date")
-		if frd is not None:
-			return frd
-		for r in self.song_dict["releases"]:
-			if "date" not in r:
-				continue
-			return r["date"]
-		return None
+		elif self.song_dict.get("first-release-date") is not None:
+			return_val = self.song_dict.get("first-release-date")
+		else:
+			for r in self.song_dict["releases"]:
+				if "date" not in r:
+					continue
+				return_val = r["date"]
+				break
+		
+		if return_val is not None:
+			if re.match(r"^\d{8}$", return_val) or re.match(r"^\d{4}-\d{2}-\d{2}$", return_val):
+				return return_val
+			elif re.match(r"^\d{4}-\d{2}$", return_val):
+				return return_val + "-01"
+			elif re.match(r"^\d{6}$", return_val):
+				return return_val + "01"
+			elif re.match(r"^\d{4}$", return_val):
+				return return_val + "-01-01"
+			else:
+				print(f"unknown date format {return_val}, skipping date metadata")
 
 	def get_mbid_tags(self):
 		"""get mbid tags with proper keys"""

--- a/shiradl/server.py
+++ b/shiradl/server.py
@@ -15,14 +15,14 @@ def send(server: WebsocketServer, data):
 def message_received(client, server, message):
     if len(message) > 200:
         message = message[:200]+"..."
-    print(f"Client({client["id"]}) said: {message}")
+    print(f"Client({client['id']}) said: {message}")
 	
 def nclient(client, server: WebsocketServer):
-	print("new client joined:", client["id"])
-	send(server, json.dumps(f"hello from server! you are client {client["id"]}"))
+	print("new client joined:", client['id'])
+	send(server, json.dumps(f"hello from server! you are client {client['id']}"))
 
 def lclient(client, server: WebsocketServer):
-	print(f"client {client["id"]} disconnected")
+	print(f"client {client['id']} disconnected")
 		
 
 def server():


### PR DESCRIPTION
For some songs, the metadata found is in the format YYYY-MM, YYYYMM or just YYYY.

In these cases I think it would be reasonable to pad these dates with (-01-)01 respectively.

Currently the script errors for a song and doesn't download it if it can't parse the metadata because of this, in the case of a different unsupported date format, a warning is shown but the song is still downloaded