### PR TITLE
Fixed lyrics error

### DIFF
--- a/shiradl/dl.py
+++ b/shiradl/dl.py
@@ -146,11 +146,11 @@ class Dl:
 			if video["id"] == video_id:
 				tags["track"] = i + 1
 				break
-		if ytmusic_watch_playlist["lyrics"]:
-			lyrics = self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"])["lyrics"]
-			if lyrics is not None:
-				tags["lyrics"] = lyrics
-		
+			if ytmusic_watch_playlist["lyrics"]:   
+				lyrics_data = self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"])
+				if lyrics_data is not None and lyrics in lyrics_data:
+					tags["lyrics"] = lyrics_data["lyrics"]
+			
 		self.tags = tags
 		return self.tags
 

--- a/shiradl/dl.py
+++ b/shiradl/dl.py
@@ -148,7 +148,7 @@ class Dl:
 				break
 			if ytmusic_watch_playlist["lyrics"]:   
 				lyrics_data = self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"])
-				if lyrics_data is not None and lyrics in lyrics_data:
+				if lyrics_data is not None and "lyrics" in lyrics_data:
 					tags["lyrics"] = lyrics_data["lyrics"]
 			
 		self.tags = tags


### PR DESCRIPTION
Sometimes self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"]) would be None, so  self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"])["lyrics"] would return an error due to the NoneType

For example for:
https://music.youtube.com/watch?v=w8JcXrATdeI

```
Traceback (most recent call last):
  File "/app/shiradl/cli.py", line 158, in cli
    tags = dl.get_tags(ytmusic_watch_playlist, track)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/shiradl/dl.py", line 119, in get_tags
    return self.__collect_tags(ytmusic_watch_playlist, track)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/shiradl/dl.py", line 150, in __collect_tags
    lyrics = self.ytmusic.get_lyrics(ytmusic_watch_playlist["lyrics"])["lyrics"]
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This should fix the error, though I'm not sure if it will have unintended consequences.